### PR TITLE
fix archive["DisplayOrder"] is nil case

### DIFF
--- a/lib/vagrant-sakura/action/list_id.rb
+++ b/lib/vagrant-sakura/action/list_id.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
           puts "%-14s %5s  %s" % ["ID", "Size", "Name"]
           r = api.get("/archive")
           r["Archives"].sort { |a, b|
-            a["DisplayOrder"] <=> b["DisplayOrder"]
+            a["DisplayOrder"].to_i <=> b["DisplayOrder"].to_i
           }.each { |archive|
             gb = archive["SizeMB"] / 1024
             puts "%-14u %3uGB  %s" % [archive["ID"], gb, archive["Name"]]


### PR DESCRIPTION
Hi! sakura-list-id command error in my environment with Vagrant 1.6.3 and vagrant-sakura (0.0.6).

```
$ vagrant sakura-list-id
Zone: is1a

---- Archives ----
ID              Size  Name
/Users/tamu2/.vagrant.d/gems/gems/vagrant-sakura-0.0.6/lib/vagrant-sakura/action/list_id.rb:18:in `sort': comparison of Hash with Hash failed (ArgumentError)
    from /Users/tamu2/.vagrant.d/gems/gems/vagrant-sakura-0.0.6/lib/vagrant-sakura/action/list_id.rb:18:in `call'
    from /Applications/Vagrant/embedded/gems/gems/vagrant-1.6.3/lib/vagrant/action/warden.rb:34:in `call'
   ...
```

I add debug code and print sakura archive API response is 

```
{"Index"=>0,
 "ID"=>"112600140111",
 "DisplayOrder"=>nil,
 "Name"=>"sacloud01_20140310",
  ...
```

`"DisplayOrder" => nil` cause this error.
`"Name"=>"sacloud01_20140310"` is my personal Archive, is not Sakura Public Archive.
Personal Archive's DisplayOrder is nil???

I saw here ...
http://stackoverflow.com/questions/3058801/overriding-rubys-spaceship-operator
`nil.to_i` give me `0`, and pull request!

Thank you. 
