### PR TITLE
Update default settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ end
 そして ``vagrant up --provider=sakura`` を実行してください。
 
 サーバのディスクソースを ``sakura.disk_source_archive`` で指定しなかった
-場合のデフォルトは ``112800438454`` で
+場合のデフォルトは ``112800520230`` で
 Ubuntu Server 14.04.4 LTS 64bit
 です。
 
@@ -124,7 +124,7 @@ $ vagrant sakura-list-id
 - ``server_name`` - サーバ名
 - ``server_plan`` - 作成するサーバのプラン ID
 - ``sshkey_id`` - サーバへのログインに利用する SSH 公開鍵のリソース ID
-- ``zone_id`` - ゾーン ID (石狩第1=`is1a`, 石狩第2=`is1b`、東京第1=`tk1a`)
+- ``zone_id`` - ゾーン ID (石狩第1=`is1a`, 石狩第2=`is1b`、東京第1=`tk1a`、デフォルトは`is1b`)
 
 ## ネットワーク
 ``vagrant-sakura`` は ``config.vm.network`` を利用したネットワークの構築を

--- a/lib/vagrant-sakura/config.rb
+++ b/lib/vagrant-sakura/config.rb
@@ -88,7 +88,7 @@ module VagrantPlugins
         end
 
         if @disk_source_archive == UNSET_VALUE
-          @disk_source_archive = 112800438454
+          @disk_source_archive = 112800520230 # Ubuntu Server 14.04.4 LTS 64bit on is1b
         end
 
         @public_key_path = nil if @public_key_path == UNSET_VALUE
@@ -106,7 +106,7 @@ module VagrantPlugins
         @use_insecure_key = false if @use_insecure_key == UNSET_VALUE
 
         if @zone_id == UNSET_VALUE
-          @zone_id = "is1a"  # the first zone
+          @zone_id = "is1b"  # the first zone
         end
       end
 


### PR DESCRIPTION
Hi @tsahara,

This PR is update defalut value settings on `config.rb`.  
They have two updates.

### 1) Update default of `zone_id`(to `is1b`)

Currently, SakuraCloud's default zone has been changed to is1b.  
For details, please see folloiwng:  
> [さくらのクラウドニュース:新規アカウントに対する石狩第1ゾーンのご利用制限開始について](http://cloud-news.sakura.ad.jp/2016/07/01/restric_account_is1a/) 

### 2) Update default of `disk_source_archive`

Currently, archive(112800438454) is not exists on the SakuraCloud.  
In addition, as the default of `zone_id` is changed, archive ID is also changed.

So, will update default of `disk_source_archive` to use available ID on `is1b` zone.
