### PR TITLE
Add detail error message

### DIFF
--- a/lib/vagrant-sakura/driver/api.rb
+++ b/lib/vagrant-sakura/driver/api.rb
@@ -53,7 +53,8 @@ module VagrantPlugins
           @logger.debug("#{request.method} #{request.path} #{request.body} "+
                         "=> #{response.code} : #{response.body}")
 
-          emsg = "#{response.code} (#{request.method} #{request.path})"
+          emsg_detail = JSON.pretty_generate JSON.parse(response.body)
+          emsg = "#{response.code} (#{request.method} #{request.path})\n#{emsg_detail}"
           case response.code
           when /2../
             # Success


### PR DESCRIPTION
Hi @tsahara,

This PR add detail error msg when API call is failed(to fix #6).

This changes output like following:  

#### AS-IS

```console
# error message
bundler: failed to load command: vagrant (/path/to/your/vagrant)
VagrantPlugins::Sakura::Driver::BadRequestError: 400 (POST /cloud/zone/is1b/api/cloud/1.1/disk)
  /path/to/your/project/lib/vagrant-sakura/driver/api.rb:62:in `do_request'
  /path/to/your/project/lib/vagrant-sakura/driver/api.rb:41:in `post'
  /path/to/your/project/lib/vagrant-sakura/action/run_instance.rb:50:in `call' 
 [...]
```

#### TO-BE

```console
# error message
bundler: failed to load command: vagrant (/path/to/your/vagrant)
VagrantPlugins::Sakura::Driver::BadRequestError: 400 (POST /cloud/zone/is1b/api/cloud/1.1/disk)
{
  "is_fatal": true,
  "serial": "xxxxxxxx10xxxxxxx20xxxxxxxx30xx",
  "status": "400 Bad Request",
  "error_code": "bad_request",
  "error_msg": "不適切な要求です。パラメータの指定誤り、入力規則違反です。入力内容をご確認ください。\nDisk.Plan.ID must be 2 (Standard Plan), 4 (SSD Plan)"
}
  /path/to/your/project/lib/vagrant-sakura/driver/api.rb:62:in `do_request'
  /path/to/your/project/lib/vagrant-sakura/driver/api.rb:41:in `post'
  /path/to/your/project/lib/vagrant-sakura/action/run_instance.rb:50:in `call' 
 [...]
```
